### PR TITLE
Implementation Fixes

### DIFF
--- a/client.go
+++ b/client.go
@@ -80,7 +80,7 @@ func (c *Client) Initialize(keyringOptions []keyring.Option) error {
 		grpcConn, err := grpc.Dial(
 			c.cfg.GRPCAddr,      // your gRPC server address.
 			grpc.WithInsecure(), // The Cosmos SDK doesn't support any transport security mechanism
-			grpc.WithDefaultCallOptions(grpc.ForceCodec(codec.NewProtoCodec(nil).GRPCCodec())),
+			grpc.WithDefaultCallOptions(grpc.ForceCodec(codec.NewProtoCodec(c.Codec.InterfaceRegistry).GRPCCodec())),
 		)
 		if err != nil {
 			initErr = fmt.Errorf("failed to dial grpc server node %s", err)

--- a/client.go
+++ b/client.go
@@ -178,12 +178,21 @@ func (c *Client) configClientContext(cctx client.Context) client.Context {
 func (c *Client) PrepareClientContext(cctx client.Context) error {
 	c.factoryLock.Lock()
 	defer c.factoryLock.Unlock()
+	kp, err := c.GetActiveKeypair()
+	if err != nil {
+		return err
+	}
 	factory, err := c.Factory.Prepare(cctx)
 	if err != nil {
 		c.log.Error("failed to prepare factory", zap.Error(err))
 		return err
 	}
 	c.Factory = factory
+	_, seq, err := c.Factory.AccountRetriever().GetAccountNumberSequence(c.CCtx, *kp)
+	if err != nil {
+		return err
+	}
+	c.Factory = c.Factory.WithSequence(seq)
 	return nil
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -24,5 +24,4 @@ func TestClient(t *testing.T) {
 	abcInfo, err := client.RPC.ABCIInfo(context.Background())
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, abcInfo.Response.LastBlockHeight, int64(1))
-	require.NotNil(t, client.ClientContext())
 }

--- a/config.go
+++ b/config.go
@@ -42,6 +42,7 @@ var (
 
 // Allows configuration of the compass client
 type ClientConfig struct {
+	// the name of that is used as the `FromName` for transaction signing
 	Key            string                  `json:"key" yaml:"key"`
 	ChainID        string                  `json:"chain-id" yaml:"chain-id"`
 	RPCAddr        string                  `json:"rpc-addr" yaml:"rpc-addr"`

--- a/config.go
+++ b/config.go
@@ -133,13 +133,13 @@ func GetOsmosisConfig(keyHome string, debug bool) *ClientConfig {
 func GetSimdConfig() *ClientConfig {
 	cfg := &ClientConfig{
 		Key:            "default",
-		ChainID:        "cosmoshub-4",
+		ChainID:        "testing",
 		RPCAddr:        "tcp://127.0.0.1:26657",
 		GRPCAddr:       "127.0.0.1:9090",
 		AccountPrefix:  "cosmos",
 		KeyringBackend: "test",
 		GasAdjustment:  1.2,
-		GasPrices:      "0.01uatom",
+		GasPrices:      "1stake",
 		MinGasAmount:   0,
 		KeyDirectory:   "keyring-test",
 		Debug:          true,

--- a/config.go
+++ b/config.go
@@ -102,6 +102,7 @@ func GetCosmosHubConfig(keyHome string, debug bool) *ClientConfig {
 		Timeout:        "20s",
 		OutputFormat:   "json",
 		SignModeStr:    "direct",
+		Modules:        ModuleBasics,
 	}
 	cfg.SetKeysDir(keyHome)
 	return cfg
@@ -124,6 +125,7 @@ func GetOsmosisConfig(keyHome string, debug bool) *ClientConfig {
 		Timeout:        "20s",
 		OutputFormat:   "json",
 		SignModeStr:    "direct",
+		Modules:        ModuleBasics,
 	}
 	cfg.SetKeysDir(keyHome)
 	return cfg
@@ -146,6 +148,7 @@ func GetSimdConfig() *ClientConfig {
 		Timeout:        "20s",
 		OutputFormat:   "json",
 		SignModeStr:    "direct",
+		Modules:        ModuleBasics,
 	}
 	cfg.SetKeysDir("keyring-test")
 	return cfg

--- a/utils.go
+++ b/utils.go
@@ -103,3 +103,13 @@ func (c *Client) BroadcastTx(ctx context.Context, msgs ...sdk.Msg) (string, erro
 		}
 	}
 }
+
+// Returns the address of the key used for transaction signing
+func (c *Client) FromAddress() string {
+	return c.cctx.FromAddress.String()
+}
+
+// Returns the name of the key used for transaction signing
+func (c *Client) FromName() string {
+	return c.cctx.GetFromName()
+}

--- a/utils.go
+++ b/utils.go
@@ -1,13 +1,18 @@
 package compass
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	libclient "github.com/cometbft/cometbft/rpc/jsonrpc/client"
+	"github.com/cosmos/cosmos-sdk/client/tx"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/go-bip39"
+	"go.uber.org/zap"
 )
 
 // Returns a Cosmos JSON-RPC websocket client
@@ -43,4 +48,53 @@ func CreateMnemonic() (string, error) {
 		return "", err
 	}
 	return mnemonic, nil
+}
+
+// Broadcasts a transaction, returning the transaction hash
+func (c *Client) BroadcastTx(ctx context.Context, msgs ...sdk.Msg) (string, error) {
+	factory, err := c.Factory.Prepare(c.CCtx)
+	if err != nil {
+		return "", fmt.Errorf("failed to prepare transaction %s", err)
+	}
+	c.log.Debug("building unsigned tx")
+	unsignedTx, err := factory.BuildUnsignedTx(msgs...)
+	if err != nil {
+		c.log.Debug("building tx failed", zap.Error(err))
+		return "", fmt.Errorf("failed to build unsigned transaction %s", err)
+	}
+	c.log.Debug("signing transaction")
+	if err := tx.Sign(c.CCtx.CmdContext, factory, c.CCtx.GetFromName(), unsignedTx, true); err != nil {
+		c.log.Debug("signing failed", zap.Error(err))
+		return "", fmt.Errorf("failed to sign transaction %s", err)
+	}
+	c.log.Debug("encoding transaction")
+	txBytes, err := c.CCtx.TxConfig.TxEncoder()(unsignedTx.GetTx())
+	if err != nil {
+		c.log.Debug("encoding failed", zap.Error(err))
+		return "", fmt.Errorf("failed to get transaction encoder %s", err)
+	}
+	c.log.Debug("broadcasting transaction")
+	res, err := c.CCtx.BroadcastTx(txBytes)
+	if err != nil {
+		c.log.Debug("broadcast failed", zap.Error(err))
+		return "", fmt.Errorf("failed to broadcast transaction %s", err)
+	}
+	c.log.Debug("confirming transaction", zap.String("tx.hash", res.TxHash))
+	exitTicker := time.After(time.Second * 10)
+	checkTicker := time.NewTicker(time.Second)
+	defer checkTicker.Stop()
+	for {
+		select {
+		case <-exitTicker:
+			return "", fmt.Errorf("failed to confirm transaction")
+		case <-checkTicker.C:
+			txRes, err := c.CCtx.Client.Tx(ctx, []byte(res.TxHash), false)
+			if err != nil {
+				c.log.Debug("status check failed", zap.Error(err), zap.String("tx.hash", res.TxHash))
+				continue
+			}
+			c.log.Info("confirmed transaction", zap.String("tx.hash", res.TxHash), zap.Any("response", txRes))
+			return res.TxHash, nil
+		}
+	}
 }


### PR DESCRIPTION
# Overview

* Fixes some improperly implemented functionality, and removes useless/confusing functions. 
* Adds custom transaction broadcast function with better predictability than upstream
  * Actually confirms the transaction
  * Better error handling / failure detection
* Tag a version `0.0.1` release after this PR is merged.

# TODO

* [x] Return transaction hashes when sending a transaction
* [x] After sending a transaction, ensure that it confirms, similiar to `go-ethereum`'s `bind.WaitMined` function